### PR TITLE
Fix faulty regex for extracting MAC addresses

### DIFF
--- a/custom_components/iphonedetect/device_tracker.py
+++ b/custom_components/iphonedetect/device_tracker.py
@@ -63,7 +63,7 @@ class Host:
                 _LOGGER.fatal("Could not probe network")
                 return False
 
-        mac = re.compile(r'(?:[0-9a-fA-F]:?){12}')
+        mac = re.compile(r'(?:[0-9A-F]{2}[:-]){5}(?:[0-9A-F]{2})', re.IGNORECASE)
 
         if re.findall(mac, output):
             _LOGGER.debug(f"Device {self.dev_id} ({self.ip_address}) is HOME")


### PR DESCRIPTION
Thanks for making this custom component. It works really well for me and allows me to track my devices' presence without using bluetooth (even Android based ones).

When I initially installed the component, I found it odd that it marked all of my devices as `home`, even though they've been disconnected from the Wi-Fi network for quite awhile. After some debugging and checking out the source code, I noticed that the regex for extracting MAC addresses is giving me false positives:

https://regex101.com/r/xZqFIs/1

```
192.168.86.209 dev enxb827eb281790  FAILED
```

Turns out, more recent versions of Debian use the `persistent names` scheme for naming network interfaces:

https://wiki.debian.org/NetworkInterfaceNames

What is used in the new naming scheme? The interface's MAC address, of course! 😄 

The regex provided in this PR will ensure that the network interface name doesn't get matched. I covered the output of both utilities (`arp` and `ip`):

* `arp` - with device activity: https://regex101.com/r/9QFrAU/1
* `arp` - without device activity: https://regex101.com/r/5PJHgJ/1
* `ip` - with device activity: https://regex101.com/r/z7DRFy/1
* `ip` - without device activity: https://regex101.com/r/nYCbaS/1