### PR TITLE
Removing HA version requirement

### DIFF
--- a/custom_components/iphonedetect/manifest.json
+++ b/custom_components/iphonedetect/manifest.json
@@ -4,6 +4,5 @@
   "documentation": "https://github.com/mudape/iphonedetect",
   "dependencies": [],
   "codeowners": ["@mudape"],
-  "requirements": [],
-  "homeassistant":"0.94.0"
+  "requirements": []
 } 


### PR DESCRIPTION
Not allowed according to hassfest ->

```
Integration iphonedetect - /github/workspace/custom_components/iphonedetect:
* [MANIFEST] Invalid manifest: extra keys not allowed @ data['homeassistant']. Got '0.94.0'
```