### PR TITLE
Core 2025.1 deprecation

### DIFF
--- a/custom_components/iphonedetect/device_tracker.py
+++ b/custom_components/iphonedetect/device_tracker.py
@@ -17,9 +17,8 @@ import subprocess
 import homeassistant.helpers.config_validation as cv
 import homeassistant.util.dt as dt_util
 import voluptuous as vol
-from homeassistant.components.device_tracker import PLATFORM_SCHEMA
+from homeassistant.components.device_tracker import PLATFORM_SCHEMA, SourceType
 from homeassistant.components.device_tracker.const import (SCAN_INTERVAL,
-                                                           SOURCE_TYPE_ROUTER,
                                                            ATTR_IP)
 from homeassistant.const import CONF_HOSTS, CONF_SCAN_INTERVAL
 
@@ -61,7 +60,7 @@ class Host:
             _LOGGER.debug(f"Device {self.dev_id} on {self.dev_ip} is HOME")
             see(dev_id=self.dev_id,
             attributes = {ATTR_IP: self.dev_ip},
-            source_type=SOURCE_TYPE_ROUTER)
+            source_type=SourceType.ROUTER)
         else:
             _LOGGER.debug(f"Device {self.dev_id} on {self.dev_ip} is AWAY")
 


### PR DESCRIPTION
SOURCE_TYPE_ROUTER was used, this is a deprecated constant which will be removed in HA Core 2025.1. Use SourceType.ROUTER instead