### PR TITLE
Fix zone miscalculation & related BaseTrackerEntity deprecation

### DIFF
--- a/custom_components/iphonedetect/device_tracker.py
+++ b/custom_components/iphonedetect/device_tracker.py
@@ -4,13 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from homeassistant.components.device_tracker import SourceType
-from homeassistant.components.device_tracker.config_entry import BaseTrackerEntity
-from homeassistant.const import (
-    EVENT_HOMEASSISTANT_STARTED,
-    STATE_HOME,
-    STATE_NOT_HOME,
-)
+from homeassistant.components.device_tracker import BaseScannerEntity, SourceType
+from homeassistant.const import EVENT_HOMEASSISTANT_STARTED
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
@@ -56,7 +51,7 @@ async def async_setup_entry(
     async_add_entities([IphoneDetectDeviceTracker(entry, coordinator)])
 
 
-class IphoneDetectDeviceTracker(CoordinatorEntity[IphoneDetectUpdateCoordinator], BaseTrackerEntity):
+class IphoneDetectDeviceTracker(CoordinatorEntity[IphoneDetectUpdateCoordinator], BaseScannerEntity):
     """Representation of a tracked device."""
 
     _attr_source_type: SourceType = SourceType.ROUTER
@@ -70,9 +65,9 @@ class IphoneDetectDeviceTracker(CoordinatorEntity[IphoneDetectUpdateCoordinator]
         self._attr_unique_id = entry.entry_id
 
     @property
-    def state(self) -> str:
-        """Return the state of the device."""
-        return STATE_HOME if self.coordinator.data.is_connected else STATE_NOT_HOME
+    def is_connected(self) -> bool:
+        """Return true if the device is connected to the network."""
+        return self.coordinator.data.is_connected or False
 
     @property
     def entity_registry_enabled_default(self) -> bool:

--- a/custom_components/iphonedetect/manifest.json
+++ b/custom_components/iphonedetect/manifest.json
@@ -5,9 +5,10 @@
   "config_flow": true,
   "dependencies": ["network"],
   "documentation": "https://github.com/mudape/iphonedetect",
+  "homeassistant": "2026.6.0",
   "integration_type": "device",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/mudape/iphonedetect/issues",
   "requirements": ["pyroute2==0.7.5"],
-  "version": "2.1.0"
+  "version": "2.5.0"
 }


### PR DESCRIPTION
As of HA 2026.6, importing BaseTrackerEntity from device_tracker.config_entry throws a deprecation warning. More importantly, zone counting now relies on the `in_zones` state attribute, which BaseTrackerEntity never sets — so when this tracker is attached to a person entity, zone.home always shows 0. Switching to BaseScannerEntity (the intended base class for connection-based trackers) fixes both issues since it handles state and in_zones automatically based on an is_connected property.

This should resolve #162 & #163.